### PR TITLE
Add syslog parsing processor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,9 +39,10 @@ require (
 	github.com/shirou/gopsutil/v4 v4.25.3
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0
-	github.com/testcontainers/testcontainers-go v0.36.0
-	github.com/trivago/grok v1.0.0
-	go.opentelemetry.io/collector/component v1.30.0
+        github.com/testcontainers/testcontainers-go v0.36.0
+        github.com/trivago/grok v1.0.0
+       github.com/leodido/go-syslog/v4 v4.2.0
+        go.opentelemetry.io/collector/component v1.30.0
 	go.opentelemetry.io/collector/component/componenttest v0.124.0
 	go.opentelemetry.io/collector/config/confighttp v0.124.0
 	go.opentelemetry.io/collector/confmap v1.30.0
@@ -146,9 +147,8 @@ require (
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/knadh/koanf/maps v0.1.2 // indirect
-	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
-	github.com/knadh/koanf/v2 v2.1.2 // indirect
-	github.com/leodido/go-syslog/v4 v4.2.0 // indirect
+        github.com/knadh/koanf/providers/confmap v0.1.0 // indirect
+        github.com/knadh/koanf/v2 v2.1.2 // indirect
 	github.com/leodido/go-urn v1.4.0 // indirect
 	github.com/leodido/ragel-machinery v0.0.0-20190525184631-5f46317e436b // indirect
 	github.com/lightstep/go-expohisto v1.0.0 // indirect

--- a/internal/collector/factories.go
+++ b/internal/collector/factories.go
@@ -9,6 +9,7 @@ import (
 	"github.com/nginx/agent/v3/internal/collector/containermetricsreceiver"
 	nginxreceiver "github.com/nginx/agent/v3/internal/collector/nginxossreceiver"
 	"github.com/nginx/agent/v3/internal/collector/nginxplusreceiver"
+	"github.com/nginx/agent/v3/internal/collector/syslogprocessor"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusexporter"
 	"github.com/open-telemetry/opentelemetry-collector-contrib/extension/headerssetterextension"
@@ -103,6 +104,7 @@ func createProcessorFactories() map[component.Type]processor.Factory {
 		memorylimiterprocessor.NewFactory(),
 		redactionprocessor.NewFactory(),
 		resourceprocessor.NewFactory(),
+		syslogprocessor.NewFactory(),
 		transformprocessor.NewFactory(),
 	}
 

--- a/internal/collector/syslogprocessor/doc.go
+++ b/internal/collector/syslogprocessor/doc.go
@@ -1,0 +1,4 @@
+package syslogprocessor
+
+// Package syslogprocessor provides an OpenTelemetry processor that parses
+// Syslog formatted log records and annotates them with structured attributes.

--- a/internal/collector/syslogprocessor/factory.go
+++ b/internal/collector/syslogprocessor/factory.go
@@ -1,0 +1,43 @@
+package syslogprocessor
+
+import (
+	"context"
+	"errors"
+
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/processor"
+	"go.opentelemetry.io/collector/processor/processorhelper"
+)
+
+// TypeStr is the identifier of the processor.
+const TypeStr = "syslog_parser"
+
+var processorType = component.MustNewType(TypeStr)
+
+// Config defines configuration for the processor. No custom options for now.
+type Config struct{}
+
+// createDefaultConfig returns an empty config.
+func createDefaultConfig() component.Config {
+	return &Config{}
+}
+
+// NewFactory creates a factory for the syslog processor.
+func NewFactory() processor.Factory {
+	return processor.NewFactory(
+		processorType,
+		createDefaultConfig,
+		processor.WithLogs(createLogsProcessor, component.StabilityLevelAlpha),
+	)
+}
+
+// createLogsProcessor instantiates the logs processor.
+func createLogsProcessor(ctx context.Context, set processor.Settings, cfg component.Config, next consumer.Logs) (processor.Logs, error) {
+	c, ok := cfg.(*Config)
+	if !ok {
+		return nil, errors.New("invalid config type")
+	}
+	_ = c // currently unused
+	return processorhelper.NewLogs(ctx, set, cfg, next, processLogs)
+}

--- a/internal/collector/syslogprocessor/processor.go
+++ b/internal/collector/syslogprocessor/processor.go
@@ -1,0 +1,61 @@
+package syslogprocessor
+
+import (
+	"context"
+	"time"
+
+	rfc3164 "github.com/leodido/go-syslog/v4/rfc3164"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+// processLogs parses syslog messages from log bodies and adds structured attributes.
+func processLogs(ctx context.Context, ld plog.Logs) (plog.Logs, error) { // nolint:revive // ctx is part of interface
+	parser := rfc3164.NewParser(rfc3164.WithBestEffort())
+
+	rl := ld.ResourceLogs()
+	for i := 0; i < rl.Len(); i++ {
+		sl := rl.At(i).ScopeLogs()
+		for j := 0; j < sl.Len(); j++ {
+			lrs := sl.At(j).LogRecords()
+			for k := 0; k < lrs.Len(); k++ {
+				lr := lrs.At(k)
+				if lr.Body().Type() != pcommon.ValueTypeStr {
+					continue
+				}
+				line := lr.Body().Str()
+				msg, err := parser.Parse([]byte(line))
+				if err != nil {
+					continue
+				}
+				m, ok := msg.(*rfc3164.SyslogMessage)
+				if !ok || !m.Valid() {
+					continue
+				}
+				attrs := lr.Attributes()
+				if m.Timestamp != nil {
+					attrs.PutStr("syslog.timestamp", m.Timestamp.Format(time.RFC3339))
+				}
+				if m.Hostname != nil {
+					attrs.PutStr("syslog.hostname", *m.Hostname)
+				}
+				if m.Appname != nil {
+					attrs.PutStr("syslog.appname", *m.Appname)
+				}
+				if m.ProcID != nil {
+					attrs.PutStr("syslog.procid", *m.ProcID)
+				}
+				if sev := m.SeverityLevel(); sev != nil {
+					attrs.PutStr("syslog.severity", *sev)
+				}
+				if fac := m.FacilityLevel(); fac != nil {
+					attrs.PutStr("syslog.facility", *fac)
+				}
+				if m.Message != nil {
+					lr.Body().SetStr(*m.Message)
+				}
+			}
+		}
+	}
+	return ld, nil
+}

--- a/internal/collector/syslogprocessor/processor_test.go
+++ b/internal/collector/syslogprocessor/processor_test.go
@@ -1,0 +1,26 @@
+package syslogprocessor
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/plog"
+)
+
+func TestProcessLogs(t *testing.T) {
+	ld := plog.NewLogs()
+	rl := ld.ResourceLogs().AppendEmpty()
+	sl := rl.ScopeLogs().AppendEmpty()
+	lr := sl.LogRecords().AppendEmpty()
+	lr.Body().SetStr("<34>Oct 11 22:14:15 mymachine su: 'su root' failed for lonvick on /dev/pts/8")
+
+	out, err := processLogs(context.Background(), ld)
+	require.NoError(t, err)
+
+	lrOut := out.ResourceLogs().At(0).ScopeLogs().At(0).LogRecords().At(0)
+	attrs := lrOut.Attributes()
+	val, ok := attrs.Get("syslog.hostname")
+	require.True(t, ok)
+	require.Equal(t, "mymachine", val.Str())
+}


### PR DESCRIPTION
## Summary
- add syslog log processor that parses RFC3164 messages into structured attributes
- register syslog processor with collector factories

## Testing
- `go test -v ./internal/collector/syslogprocessor -run TestProcessLogs -count=1`


------
https://chatgpt.com/codex/tasks/task_e_6890c52ab41083208c00242cfe55365e